### PR TITLE
Fallback for gradient texts on older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^22.13.10",
     "sass": "^1.85.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.15.3(solid-js@1.9.4)
       '@tailwindcss/vite':
         specifier: ^4.0.9
-        version: 4.0.9(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
+        version: 4.0.9(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
       solid-js:
         specifier: ^1.9.3
         version: 1.9.4
@@ -27,6 +27,9 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
     devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.10
       sass:
         specifier: ^1.85.1
         version: 1.85.1
@@ -35,10 +38,10 @@ importers:
         version: 5.7.2
       vite:
         specifier: ^6.0.0
-        version: 6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
+        version: 6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
       vite-plugin-solid:
         specifier: ^2.11.1
-        version: 2.11.1(solid-js@1.9.4)(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
+        version: 2.11.1(solid-js@1.9.4)(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
 
 packages:
 
@@ -607,6 +610,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/node@22.13.10':
+    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+
   babel-plugin-jsx-dom-expressions@0.39.3:
     resolution: {integrity: sha512-6RzmSu21zYPlV2gNwzjGG9FgODtt9hIWnx7L//OIioIEuRcnpDZoY8Tr+I81Cy1SrH4qoDyKpwHHo6uAMAeyPA==}
     peerDependencies:
@@ -902,6 +908,9 @@ packages:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
@@ -1411,13 +1420,13 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.0.9
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.9
 
-  '@tailwindcss/vite@4.0.9(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))':
+  '@tailwindcss/vite@4.0.9(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))':
     dependencies:
       '@tailwindcss/node': 4.0.9
       '@tailwindcss/oxide': 4.0.9
       lightningcss: 1.29.1
       tailwindcss: 4.0.9
-      vite: 6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
+      vite: 6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1441,6 +1450,10 @@ snapshots:
       '@babel/types': 7.26.0
 
   '@types/estree@1.0.6': {}
+
+  '@types/node@22.13.10':
+    dependencies:
+      undici-types: 6.20.0
 
   babel-plugin-jsx-dom-expressions@0.39.3(@babel/core@7.26.0):
     dependencies:
@@ -1731,6 +1744,8 @@ snapshots:
 
   typescript@5.7.2: {}
 
+  undici-types@6.20.0: {}
+
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
       browserslist: 4.24.2
@@ -1739,7 +1754,7 @@ snapshots:
 
   validate-html-nesting@1.2.2: {}
 
-  vite-plugin-solid@2.11.1(solid-js@1.9.4)(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)):
+  vite-plugin-solid@2.11.1(solid-js@1.9.4)(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
@@ -1747,24 +1762,25 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.4
       solid-refresh: 0.6.3(solid-js@1.9.4)
-      vite: 6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
-      vitefu: 1.0.4(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
+      vite: 6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
+      vitefu: 1.0.4(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1):
+  vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.3
       rollup: 4.34.9
     optionalDependencies:
+      '@types/node': 22.13.10
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.1
       sass: 1.85.1
 
-  vitefu@1.0.4(vite@6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)):
+  vitefu@1.0.4(vite@6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)):
     optionalDependencies:
-      vite: 6.0.9(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
+      vite: 6.0.9(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.85.1)
 
   yallist@3.1.1: {}

--- a/src/components/general/demo-modal/index.tsx
+++ b/src/components/general/demo-modal/index.tsx
@@ -220,7 +220,7 @@ export default function FireAIDemoModal(props: ModalProps) {
             >
               <h2 class="text-[26px] font-medium text-center leading-[40px] mb-3">
                 Book a Free{" "}
-                <span class="bg-gradient-to-r from-[#0600A3] via-[#0169FD] to-[#000] text-transparent bg-clip-text">
+                <span class="text-[#322638] bg-gradient-to-r from-[#0600A3] via-[#0169FD] to-[#000] text-transparent bg-clip-text">
                 FireAI{" "}
               </span>
                 De

--- a/src/components/pages/home/HeroSection.tsx
+++ b/src/components/pages/home/HeroSection.tsx
@@ -24,7 +24,7 @@ const HeroSection: Component = () => {
       <div class="mx-auto">
       <div class="w-full md:w-8/12 mx-auto">
         <h2 class="text-3xl md:text-4xl lg:text-5xl pt-30 font-medium">
-          AI-Powered Business <span class="bg-gradient-to-r from-[#322638] via-blue-400 to-[#322638] text-transparent bg-clip-text">Intelligence </span>
+          AI-Powered Business <span class="text-[#322638] bg-gradient-to-r from-[#322638] via-blue-400 to-[#322638] text-transparent bg-clip-text">Intelligence </span>
           <br class="hidden lg:block" />
           at Your Fingertips
         </h2>

--- a/src/components/pages/home/OurSolutionsSection.tsx
+++ b/src/components/pages/home/OurSolutionsSection.tsx
@@ -43,7 +43,7 @@ const CarouselSection = () => {
             <span class="text-gray-700">Our Solutions</span>
           </div>
           <h2 class="text-3xl md:text-4xl lg:text-5xl font-medium leading-tight">
-            Simplifying <span class="bg-gradient-to-r from-[#0600A3] via-[#322638] to-[#0169FD] text-transparent bg-clip-text">Complex Data</span>{" "}
+            Simplifying <span class="text-[#322638] bg-gradient-to-r from-[#0600A3] via-[#322638] to-[#0169FD] text-transparent bg-clip-text">Complex Data</span>{" "}
             <br class="hidden md:block" />
             for Smarter and Faster Decisions
           </h2>


### PR DESCRIPTION
On older browsers, gradient text was not working, and it was being shown as transparent (hidden). This PR fixes it by adding a fallback color to the text. 